### PR TITLE
Update python_version for 3.13

### DIFF
--- a/arboraps.json
+++ b/arboraps.json
@@ -10,7 +10,7 @@
     "product_version_regex": ".*",
     "min_phantom_version": "4.9.39220",
     "fips_compliant": true,
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "publisher": "Splunk community",
     "license": "Copyright (c) 2017-2025 Splunk Inc.",
     "app_version": "3.0.1",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)