### PR TITLE
fix: verify Arbor APS certificates by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.0
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Arbor APS
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Arbor APS
 
-Publisher: Splunk community \
-Connector Version: 3.0.1 \
-Product Vendor: Arbor Networks \
-Product Name: Arbor Networks APS \
+Publisher: Splunk community <br>
+Connector Version: 3.0.1 <br>
+Product Vendor: Arbor Networks <br>
+Product Name: Arbor Networks APS <br>
 Minimum Product Version: 4.9.39220
 
 This app integrates with Arbor Networks APS to execute containment and corrective actions
@@ -21,18 +21,18 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[list ips](#action-list-ips) - List all IPs on the outbound Blocklist or Allowlist \
-[block ip](#action-block-ip) - Add an IP to the outbound Blocklist \
-[unblock ip](#action-unblock-ip) - Remove an IP from the outbound Blocklist \
-[allow ip](#action-allow-ip) - Add an IP to the outbound Allowlist \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[list ips](#action-list-ips) - List all IPs on the outbound Blocklist or Allowlist <br>
+[block ip](#action-block-ip) - Add an IP to the outbound Blocklist <br>
+[unblock ip](#action-unblock-ip) - Remove an IP from the outbound Blocklist <br>
+[allow ip](#action-allow-ip) - Add an IP to the outbound Allowlist <br>
 [unallow ip](#action-unallow-ip) - Remove an IP from the outbound Allowlist
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -47,7 +47,7 @@ No Output
 
 List all IPs on the outbound Blocklist or Allowlist
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -73,7 +73,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Add an IP to the outbound Blocklist
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -100,7 +100,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Remove an IP from the outbound Blocklist
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -125,7 +125,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Add an IP to the outbound Allowlist
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -153,7 +153,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Remove an IP from the outbound Allowlist
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -178,7 +178,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/arboraps.json
+++ b/arboraps.json
@@ -28,7 +28,7 @@
         "verify_server_cert": {
             "description": "Verify server certificate",
             "data_type": "boolean",
-            "default": false,
+            "default": true,
             "order": 1
         },
         "username": {

--- a/arboraps.json
+++ b/arboraps.json
@@ -12,7 +12,7 @@
     "fips_compliant": true,
     "python_version": "3",
     "publisher": "Splunk community",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "app_version": "3.0.1",
     "utctime_updated": "2025-04-11T20:19:41.625447Z",
     "package_name": "phantom_arboraps",
@@ -507,5 +507,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/arboraps_connector.py
+++ b/arboraps_connector.py
@@ -58,7 +58,7 @@ class ArborApsConnector(BaseConnector):
         self._server_url = None
         self._username = None
         self._password = None
-        self._verify_server_cert = False
+        self._verify_server_cert = True
         self._session = None
 
         return
@@ -78,7 +78,7 @@ class ArborApsConnector(BaseConnector):
         self._server_url = config[ARBORAPS_TA_CONFIG_SERVER_URL].strip("/")
         self._username = config[ARBORAPS_TA_CONFIG_USERNAME]
         self._password = config[ARBORAPS_TA_CONFIG_PASSWORD]
-        self._verify_server_cert = config.get(ARBORAPS_TA_CONFIG_VERIFY_SSL, False)
+        self._verify_server_cert = config.get(ARBORAPS_TA_CONFIG_VERIFY_SSL, True)
 
         # Custom validation for IP address
         self.set_validator(ARBORAPS_TA_PARAM_IP, self._is_ip)

--- a/arboraps_connector.py
+++ b/arboraps_connector.py
@@ -1,6 +1,6 @@
 # File: arboraps_connector.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/arboraps_consts.py
+++ b/arboraps_consts.py
@@ -1,6 +1,6 @@
 # File: arboraps_consts.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Enabled TLS certificate verification by default for Arbor APS connections.


### PR DESCRIPTION
### Bug Fixes

- Enable TLS certificate verification by default in both the asset manifest and connector fallback behavior.
- Preserve an explicit asset-level opt-out for deployments that require an unverified certificate.
- Refresh shared pre-commit hooks and generated connector metadata before the functional remediation.

Tracking: [PAPP-38014](https://splunk.atlassian.net/browse/PAPP-38014), [PSAAS-31338](https://splunk.atlassian.net/browse/PSAAS-31338).

### Manual Documentation

- [x] I have verified that no manual documentation change is required; the existing `verify_server_cert` asset setting remains available and only its secure default changes.

### Testing

- `python3 -m compileall -q .`
- `pre-commit run --all-files` (all required local hooks pass; Semgrep is permitted to fail and Docker packaging is delegated to hosted CI)

No connector-local unit-test scaffolding was added because this is a legacy BaseConnector app.

Written by Codex with AI assistance.